### PR TITLE
update Dockerfile and terraform lock file

### DIFF
--- a/aws-cms-oit-iusg-spe-cmcs-macbis-dev/.terraform.lock.hcl
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-dev/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "~> 3.30.0"
   hashes = [
     "h1:PmKa3uxO2mDA5FJfGmpX+4e0x70vFLV5Ka9NxkuMpUo=",
+    "h1:z9kdXY2A/+dIZrPy9hNlg/B5I/AuETQsp0jz9EgprIQ=",
     "zh:01f562a6a31fe46a8ca74804f360e3452b26f71abc549ce1f0ab5a8af2484cdf",
     "zh:25bacc5ed725051f0ab1f7d575e45c901e5b8e1d50da4156a31dda92b2b7e481",
     "zh:349b79979d9169db614d8ebd1bc2e0caeb7a38dc816e261b8b2b4b5204615519",

--- a/password-rotation.Dockerfile
+++ b/password-rotation.Dockerfile
@@ -8,4 +8,5 @@ RUN cd /build; CGO_ENABLED=0 GOBIN=/bin/ go install .
 FROM scratch
 COPY --from=build /bin/portal-test-user-manager /bin/portal-test-user-manager
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /tmp /tmp
 ENTRYPOINT ["/bin/portal-test-user-manager"]


### PR DESCRIPTION
This PR:
- updates the Dockerfile by adding `/tmp` dir to scratch image.
- updates the terraform lock file with a hash based on my dev environment

Tested:
successfully built an image with the Dockerfile and pushed it to ECR repo
the application successfully runs on ECS
