### PR TITLE
set variables to values for MAC-FC dev environment

### DIFF
--- a/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
@@ -9,11 +9,11 @@ module "password_rotation" {
   image_tag                = "latest"
   ecs_vpc_id               = "vpc-043ae3133b10db9a0"
   ecs_subnet_ids           = ["subnet-03f688f7435a936d7", "subnet-0fb2cb5b2036a5c6a"] // private subnets
-  schedule_task_expression = "cron(0/1 * * * ? *)"                                    // every 1 minute
-  event_rule_enabled       = false
+  schedule_task_expression = "cron(0 21 * * ? *)"                                     // every day at 4 PM ET
+  event_rule_enabled       = true
 
   s3_bucket       = "bharvey-test-same-account-bucket"
-  s3_key          = "example.txt"
+  s3_key          = "macfin-macfc-portal-users.xlsx"
   username_header = "UserName"
   password_header = "Password"
 
@@ -27,5 +27,5 @@ module "password_rotation" {
 
   idm_hostname_dev  = "test.idp.idm.cms.gov"
   idm_hostname_val  = "impl.idp.idm.cms.gov"
-  idm_hostname_prod = "idp.idm.cms.gov"
+  idm_hostname_prod = "idm.cms.gov"
 }

--- a/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
@@ -20,12 +20,4 @@ module "password_rotation" {
   sheet_name_dev  = "Portal-DEV"
   sheet_name_val  = "Portal-VAL"
   sheet_name_prod = "Portal-PROD"
-
-  portal_hostname_dev  = "portaldev.cms.gov"
-  portal_hostname_val  = "portalval.cms.gov"
-  portal_hostname_prod = "portal.cms.gov"
-
-  idm_hostname_dev  = "test.idp.idm.cms.gov"
-  idm_hostname_val  = "impl.idp.idm.cms.gov"
-  idm_hostname_prod = "idm.cms.gov"
 }

--- a/password-rotation/README.md
+++ b/password-rotation/README.md
@@ -3,20 +3,16 @@
 A Terraform module which deploys a scheduled ECS task on a cron schedule.  This task runs an application which pulls a test user spreadsheet from S3, rotates the Enterprise Portal passwords for the test users, updates the spreadsheet, and pushes it back to S3. To read more about the password rotation application, see the README (TBD)
 
 ## Usage
-See [variables.tf](variables.tf) for variable descriptions. Commented variables are defined as defaults. 
+See [variables.tf](variables.tf) for variable descriptions.
 ```
 module "password-rotation" {
   source      = "github.com/CMSgov/portal-test-user-manager//password-rotation
   
   environment = ""
-  # app_name    = "password-rotation"
-  # task_name   = "scheduled-runner"
 
   repo_url                    = "" 
-  # image_tag                 = "latest" # this value should not be changed
   ecs_vpc_id                  = "" 
-  ecs_subnet_ids              = [] 
-  # schedule_task_expression  = "0 8 1 * ? *" # monthly on the first day of the month at 8am UTC (3am UTC-5)
+  ecs_subnet_ids              = []
   # event_rule_enabled        = true
 
   s3_bucket            = ""

--- a/password-rotation/README.md
+++ b/password-rotation/README.md
@@ -27,14 +27,6 @@ module "password-rotation" {
   sheet_name_dev       = ""
   sheet_name_val       = ""
   sheet_name_prod      = ""
-
-  # portal_hostname_dev  = "portaldev.cms.gov"
-  # portal_hostname_val  = "portalval.cms.gov"
-  # portal_hostname_prod = "portal.cms.gov"
-  
-  # idm_hostname_dev     = "test.idp.idm.cms.gov"
-  # idm_hostname_val     = "impl.idp.idm.cms.gov"
-  # idm_hostname_prod    = "idm.cms.gov"
 }
 ```
 

--- a/password-rotation/README.md
+++ b/password-rotation/README.md
@@ -3,7 +3,7 @@
 A Terraform module which deploys a scheduled ECS task on a cron schedule.  This task runs an application which pulls a test user spreadsheet from S3, rotates the Enterprise Portal passwords for the test users, updates the spreadsheet, and pushes it back to S3. To read more about the password rotation application, see the README (TBD)
 
 ## Usage
-See [variables.tf](variables.tf) for variable descriptions.
+See [variables.tf](variables.tf) for variable descriptions. To enable the scheduled task to run, uncomment `event_rule_enabled = true`. To disable it, comment out the line.
 ```
 module "password-rotation" {
   source      = "github.com/CMSgov/portal-test-user-manager//password-rotation

--- a/password-rotation/README.md
+++ b/password-rotation/README.md
@@ -30,11 +30,11 @@ module "password-rotation" {
 
   # portal_hostname_dev  = "portaldev.cms.gov"
   # portal_hostname_val  = "portalval.cms.gov"
-  # portal_hostname_prod = "portalval.cms.gov"
+  # portal_hostname_prod = "portal.cms.gov"
   
   # idm_hostname_dev     = "test.idp.idm.cms.gov"
   # idm_hostname_val     = "impl.idp.idm.cms.gov"
-  # idm_hostname_prod    = "idp.idm.cms.gov"
+  # idm_hostname_prod    = "idm.cms.gov"
 }
 ```
 

--- a/password-rotation/variables.tf
+++ b/password-rotation/variables.tf
@@ -117,5 +117,5 @@ variable "idm_hostname_val" {
 variable "idm_hostname_prod" {
   type        = string
   description = "Hostname for prod CMS Enterprise Portal IDM"
-  default     = "idp.idm.cms.gov"
+  default     = "idm.cms.gov"
 }

--- a/password-rotation/variables.tf
+++ b/password-rotation/variables.tf
@@ -45,7 +45,7 @@ variable "schedule_task_expression" {
 variable "event_rule_enabled" {
   type        = bool
   description = "Whether the event rule that triggers the task is enabled"
-  default     = true
+  default     = false
 }
 
 variable "s3_bucket" {


### PR DESCRIPTION
The changes to variable values in the module instantiation are necessary to run the code in the MAC-FC dev environment.
Removed the portal hostnames from the top-level.

module changes:
The PROD portal hostname was corrected. The correct name is `idm.cms.gov` .
Removed the portal hostnames from the README, since the portal hostnames rarely change, if ever.

Tested:
ran `terraform apply` and verified there are no unexpected diffs between the terraform config and AWS infrastructure.