### PR TITLE
add path, boundary to iam roles; add path to iam policies

### DIFF
--- a/password-rotation/main.tf
+++ b/password-rotation/main.tf
@@ -1,5 +1,7 @@
 locals {
   awslogs_group = "/aws/ecs/${var.app_name}-${var.environment}-${var.task_name}"
+  iam_path      = "/delegatedadmin/developer/"
+  iam_boundary  = "arn:aws:iam::037370603820:policy/cms-cloud-admin/ct-ado-poweruser-permissions-boundary-policy"
 }
 
 data "aws_partition" "current" {}
@@ -26,10 +28,12 @@ data "aws_iam_policy_document" "events_assume_role_policy" {
 }
 
 resource "aws_iam_role" "cloudwatch_target_role" {
-  name                = "cw-target-role-${var.app_name}-${var.environment}-${var.task_name}"
-  description         = "Role allowing CloudWatch Events to run the task"
-  assume_role_policy  = data.aws_iam_policy_document.events_assume_role_policy.json
-  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"]
+  path                 = local.iam_path
+  permissions_boundary = local.iam_boundary
+  name                 = "cw-target-role-${var.app_name}-${var.environment}-${var.task_name}"
+  description          = "Role allowing CloudWatch Events to run the task"
+  assume_role_policy   = data.aws_iam_policy_document.events_assume_role_policy.json
+  managed_policy_arns  = ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"]
 }
 
 ## ECS roles
@@ -52,10 +56,12 @@ data "aws_iam_policy_document" "ecs_assume_role_policy" {
 # ECS task role
 
 resource "aws_iam_role" "task_role" {
-  name                = "ecs-task-role-${var.app_name}-${var.environment}-${var.task_name}"
-  description         = "Role granting permissions to the ECS container task"
-  assume_role_policy  = data.aws_iam_policy_document.ecs_assume_role_policy.json
-  managed_policy_arns = [aws_iam_policy.s3_access.arn]
+  path                 = local.iam_path
+  permissions_boundary = local.iam_boundary
+  name                 = "ecs-task-role-${var.app_name}-${var.environment}-${var.task_name}"
+  description          = "Role granting permissions to the ECS container task"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  managed_policy_arns  = [aws_iam_policy.s3_access.arn]
 }
 
 data "aws_iam_policy_document" "s3_access" {
@@ -67,6 +73,7 @@ data "aws_iam_policy_document" "s3_access" {
 }
 
 resource "aws_iam_policy" "s3_access" {
+  path        = local.iam_path
   name        = "${var.s3_bucket}-s3-access"
   description = "Policy granting access to the S3 bucket containing the test user spreadsheet"
   policy      = data.aws_iam_policy_document.s3_access.json
@@ -75,10 +82,12 @@ resource "aws_iam_policy" "s3_access" {
 # ECS task execution role
 
 resource "aws_iam_role" "task_execution_role" {
-  name                = "ecs-task-exec-role-${var.app_name}-${var.environment}-${var.task_name}"
-  description         = "Role granting permissions to the ECS container agent/Docker daemon"
-  assume_role_policy  = data.aws_iam_policy_document.ecs_assume_role_policy.json
-  managed_policy_arns = [aws_iam_policy.parameter_store.arn, "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
+  path                 = local.iam_path
+  permissions_boundary = local.iam_boundary
+  name                 = "ecs-task-exec-role-${var.app_name}-${var.environment}-${var.task_name}"
+  description          = "Role granting permissions to the ECS container agent/Docker daemon"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  managed_policy_arns  = [aws_iam_policy.parameter_store.arn, "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
 data "aws_iam_policy_document" "parameter_store" {
@@ -91,6 +100,7 @@ data "aws_iam_policy_document" "parameter_store" {
 
 resource "aws_iam_policy" "parameter_store" {
   name        = "${var.app_name}-${var.environment}-${var.task_name}-parameter-store"
+  path        = local.iam_path
   description = "Policy granting access to parameter store"
   policy      = data.aws_iam_policy_document.parameter_store.json
 }

--- a/password-rotation/main.tf
+++ b/password-rotation/main.tf
@@ -1,7 +1,10 @@
+# documentation about iam_path and iam_boundary settings is documented here:
+# https://cloud.cms.gov/creating-identity-access-management-policies
+
 locals {
   awslogs_group = "/aws/ecs/${var.app_name}-${var.environment}-${var.task_name}"
   iam_path      = "/delegatedadmin/developer/"
-  iam_boundary  = "arn:aws:iam::037370603820:policy/cms-cloud-admin/ct-ado-poweruser-permissions-boundary-policy"
+  iam_boundary  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
 }
 
 data "aws_partition" "current" {}


### PR DESCRIPTION
This PR follows the docs [here](https://cloud.cms.gov/creating-identity-access-management-policies) that explain that each iam_role and iam_policy must have the `path` attribute set to `/delegatedadmin/developer/` . This setting allows users with cloudtamer roles to have sufficient iam permissions.

I set the boundary value to the permissions boundary arn that is associated with my cloudtamer role, rather than the one documented. Per Rabee Zuberi, `the boundary policy will attach automatically.` so it's value in terraform doesn't matter.

With this, I can now modify the password-rotation scheduled task terraform, as necessary.

Tested:
Verified I could change a container environment variables (`KEY`), and add new environment variables, which destroy/create task definition. I could not do this before.