### PR TITLE
add send mail feature to password-rotation application

### DIFF
--- a/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
@@ -20,4 +20,6 @@ module "password_rotation" {
   sheet_name_dev  = "Portal-DEV"
   sheet_name_val  = "Portal-VAL"
   sheet_name_prod = "Portal-PROD"
+
+  mail_enabled = "false" // To mail the xlsx file, in addition to uploading it to S3, set to "true"
 }

--- a/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
@@ -21,5 +21,6 @@ module "password_rotation" {
   sheet_name_val  = "Portal-VAL"
   sheet_name_prod = "Portal-PROD"
 
-  mail_enabled = "false" // To mail the xlsx file, in addition to uploading it to S3, set to "true"
+  mail_enabled = "true" // To mail the xlsx file, in addition to uploading it to S3, set to "true"
+  to_addresses = "leslie@corbalt.com, lesliebklein@gmail.com"
 }

--- a/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-dev/password_rotation.tf
@@ -21,6 +21,6 @@ module "password_rotation" {
   sheet_name_val  = "Portal-VAL"
   sheet_name_prod = "Portal-PROD"
 
-  mail_enabled = "true" // To mail the xlsx file, in addition to uploading it to S3, set to "true"
-  to_addresses = "leslie@corbalt.com, lesliebklein@gmail.com"
+  mail_enabled = "false" // To mail the xlsx file, in addition to uploading it to S3, set to "true"
+  to_addresses = "macfintestingteam@dcca.com"
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.42.25
 	github.com/aws/aws-sdk-go-v2/config v1.11.1
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.4 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.22.0
 	github.com/xuri/excelize/v2 v2.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,8 @@
 github.com/aws/aws-sdk-go v1.42.25 h1:BbdvHAi+t9LRiaYUyd53noq9jcaAcfzOhSVbKfr6Avs=
 github.com/aws/aws-sdk-go v1.42.25/go.mod h1:gyRszuZ/icHmHAVE4gc/r+cfCmhA1AD+vqfWbgI+eHs=
-github.com/aws/aws-sdk-go-v2 v1.11.2 h1:SDiCYqxdIYi6HgQfAWRhgdZrdnOuGyLDJVRSWLeHWvs=
 github.com/aws/aws-sdk-go-v2 v1.11.2/go.mod h1:SQfA+m2ltnu1cA0soUkj4dRSsmITiVQUJvBIZjzfPyQ=
+github.com/aws/aws-sdk-go-v2 v1.13.0 h1:1XIXAfxsEmbhbj5ry3D3vX+6ZcUYvIqSm4CWWEuGZCA=
+github.com/aws/aws-sdk-go-v2 v1.13.0/go.mod h1:L6+ZpqHaLbAaxsqV0L4cvxZY7QupWJB4fhkf8LXvC7w=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0 h1:yVUAwvJC/0WNPbyl0nA3j1L6CW1CN8wBubCRqtG7JLI=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0/go.mod h1:Xn6sxgRuIDflLRJFj5Ev7UxABIkNbccFPV/p8itDReM=
 github.com/aws/aws-sdk-go-v2/config v1.11.1 h1:KXSjb7ZMLRtjxClFptukTYibiOqJS9NwBO+9WD3UMto=
@@ -10,10 +11,12 @@ github.com/aws/aws-sdk-go-v2/credentials v1.6.5 h1:ZrsO2js2v4T95rsCIWoAb/ck5+U1k
 github.com/aws/aws-sdk-go-v2/credentials v1.6.5/go.mod h1:HWSOnsnqVMbLcWUmom6AN1cqhcLzLJ62AObW28CbYbU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.8.2 h1:KiN5TPOLrEjbGCvdTQR4t0U4T87vVwALZ5Bg3jpMqPY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.8.2/go.mod h1:dF2F6tXEOgmW5X1ZFO/EPtWrcm7XkW07KNcJUGNtt4s=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.2 h1:XJLnluKuUxQG255zPNe+04izXl7GSyUVafIsgfv9aw4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.2/go.mod h1:SgKKNBIoDC/E1ZCDhhMW3yalWjwuLjMcpLzsM/QQnWo=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.0.2 h1:EauRoYZVNPlidZSZJDscjJBQ22JhVF2+tdteatax2Ak=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.4 h1:CRiQJ4E2RhfDdqbie1ZYDo8QtIo75Mk7oTdJSfwJTMQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.4/go.mod h1:XHgQ7Hz2WY2GAn//UXHofLfPXWh+s62MbMOijrg12Lw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.0.2/go.mod h1:xT4XX6w5Sa3dhg50JrYyy3e4WPYo/+WjY/BXtqXVunU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.2.0 h1:3ADoioDMOtF4uiK59vCpplpCwugEU+v4ZFD29jDL3RQ=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.2.0/go.mod h1:BsCSJHx5DnDXIrOcqB8KN1/B+hXLG/bi4Y6Vjcx/x9E=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.2 h1:IQup8Q6lorXeiA/rK72PeToWoWK8h7VAPgHNWdSrtgE=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.2/go.mod h1:VITe/MdW6EMXPb0o0txu/fsonXbMHUU2OC2Qp7ivU4o=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.5.0 h1:lPLbw4Gn59uoKqvOfSnkJr54XWk5Ak1NK20ZEiSWb3U=
@@ -28,8 +31,9 @@ github.com/aws/aws-sdk-go-v2/service/sso v1.7.0 h1:E4fxAg/UE8a6yiLZYv8/EP0uXKPPR
 github.com/aws/aws-sdk-go-v2/service/sso v1.7.0/go.mod h1:KnIpszaIdwI33tmc/W/GGXyn22c1USYxA/2KyvoeDY0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.12.0 h1:7g0252k2TF3eA1DtfkTQB/tqI41YvbUPaolwTR0/ITc=
 github.com/aws/aws-sdk-go-v2/service/sts v1.12.0/go.mod h1:UV2N5HaPfdbDpkgkz4sRzWCvQswZjdO1FfqCWl0t7RA=
-github.com/aws/smithy-go v1.9.0 h1:c7FUdEqrQA1/UVKKCNDFQPNKGp4FQg3YW4Ck5SLTG58=
 github.com/aws/smithy-go v1.9.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
+github.com/aws/smithy-go v1.10.0 h1:gsoZQMNHnX+PaghNw4ynPsyGP7aUCqx5sY2dlPQsZ0w=
+github.com/aws/smithy-go v1.10.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/mail.go
+++ b/mail.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/mail"
+	"net/smtp"
+	"net/textproto"
+	"os"
+	"strings"
+	"time"
+
+	b64 "encoding/base64"
+
+	"github.com/xuri/excelize/v2"
+)
+
+const (
+	mailSubject      = "MACFin portal test accounts"
+	AttachedFileName = "MACFin_test_accounts.xlsx"
+	bodyEncoding     = "base64"
+	charSet          = "UTF-8"
+)
+
+const (
+	FileMimeType           = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	FileContentDisposition = "attachment"
+)
+
+const (
+	SMTPHost = "internal-Enterpris-SMTPProd-I20YLD1GTM6L-357506541.us-east-1.elb.amazonaws.com"
+	SMTPPort = "25"
+)
+
+type SMTPRelay struct {
+	Host string
+	Port string
+}
+
+type Message struct {
+	fromAddress string
+	senderName  string
+	toAddresses []string
+	subject     string
+	headers     textproto.MIMEHeader
+	body        *bytes.Buffer
+	err         error
+	mailEnabled string
+}
+
+type File struct {
+	name     string
+	mimeType string
+	data     []byte
+}
+
+func newFile(f *excelize.File) (*File, error) {
+	fp, err := os.Open(f.Path)
+	if err != nil {
+		return nil, err
+	}
+	defer fp.Close()
+
+	data, err := io.ReadAll(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{
+		name:     AttachedFileName,
+		mimeType: FileMimeType,
+		data:     data,
+	}, nil
+
+}
+
+func (m *Message) setHeader(header, value string) *Message {
+	h := textproto.CanonicalMIMEHeaderKey(header)
+	m.headers.Set(h, value)
+
+	return m
+}
+
+func (m *Message) addHeader(header, value string) *Message {
+	h := textproto.CanonicalMIMEHeaderKey(header)
+	m.headers.Add(h, value)
+
+	return m
+}
+
+func (m *Message) addRecipientAddresses(addresses ...string) *Message {
+	for _, addr := range addresses {
+		m.addHeader("To", addr)
+	}
+	return m
+}
+
+func (m *Message) SetFrom() *Message {
+	if m.err != nil {
+		return m
+	}
+
+	m.setHeader("From", m.senderName+" <"+m.fromAddress+">")
+	return m
+}
+
+func (m *Message) SetSubject() *Message {
+	if m.err != nil {
+		return m
+	}
+
+	m.setHeader("Subject", m.subject)
+	return m
+}
+
+func (m *Message) AddTo(addresses ...string) *Message {
+	if m.err != nil {
+		return m
+	}
+
+	m.addRecipientAddresses(addresses...)
+
+	return m
+}
+
+// create a multipart MIME message with text and file attachment
+func (m *Message) SetBody(multipartType string, f *excelize.File) *Message {
+	if m.err != nil {
+		return m
+	}
+
+	var header textproto.MIMEHeader
+
+	// create a new multipart writer
+	writer := multipart.NewWriter(m.body)
+	contentType := "multipart/" + multipartType + ";\n \tboundary=" + writer.Boundary()
+	// add header to main header group
+	m.setHeader("Content-Type", contentType)
+
+	// add text part
+	textBody := "\r\nPlease see attached file with portal accounts.\r\n"
+	header = make(textproto.MIMEHeader)
+	header.Set("Content-Type", "text/plain; charset="+charSet)
+	header.Set("Content-Transfer-Encoding", bodyEncoding)
+	p, err := writer.CreatePart(header)
+	if err != nil {
+		m.err = err
+		return m
+	}
+	_, err = p.Write([]byte(b64.StdEncoding.EncodeToString([]byte(textBody))))
+	if err != nil {
+		m.err = err
+		return m
+	}
+
+	// add file attachment part
+	ft, err := newFile(f)
+	if err != nil {
+		m.err = err
+		return m
+	}
+
+	header = make(textproto.MIMEHeader)
+	value := fmt.Sprintf("%s;\n \tname=%q", ft.mimeType, ft.name)
+	header.Set("Content-Type", value)
+	header.Set("Content-Transfer-Encoding", bodyEncoding)
+	value = fmt.Sprintf("attachment;\n \tfilename=%q", ft.name)
+	header.Set("Content-Disposition", value)
+	p, err = writer.CreatePart(header)
+	if err != nil {
+		m.err = err
+		return m
+	}
+	_, err = p.Write([]byte(b64.StdEncoding.EncodeToString(ft.data)))
+	if err != nil {
+		m.err = err
+		return m
+	}
+
+	err = writer.Close()
+	if err != nil {
+		m.err = err
+		return m
+	}
+
+	return m
+}
+
+func (m *Message) MIMEString() string {
+	return m.getHeaders() + m.body.String()
+}
+
+func (m *Message) getHeaders() (headers string) {
+	m.setHeader("Date", time.Now().Format(time.RFC1123Z))
+
+	// combine the headers
+	for header, values := range m.headers {
+		headers += header + ": " + strings.Join(values, ", ") + "\r\n"
+	}
+
+	headers = headers + "\r\n"
+
+	return
+
+}
+
+func (m *Message) validateRecipientAddresses() *Message {
+	// remove duplicate addresses
+	// log invalid address and continue
+	// if no valid address, set m.err
+	addresses := make([]string, 0)
+	addressSet := make(map[string]bool)
+	for _, addr := range m.toAddresses {
+		if len(addr) > 0 {
+			a, err := mail.ParseAddress(addr)
+			if err != nil {
+				log.Printf("validating recipient address %s: %s", addr, err)
+				continue
+			}
+			if _, ok := addressSet[a.Address]; !ok {
+				addressSet[a.Address] = true
+				addresses = append(addresses, a.Address)
+			}
+		} else {
+			continue
+		}
+	}
+	if len(addresses) == 0 {
+		m.err = fmt.Errorf("no valid recipient address")
+		return m
+	}
+
+	m.toAddresses = addresses
+
+	return m
+}
+
+func sendEmail(f *excelize.File) error {
+	smtpRelay := &SMTPRelay{
+		Host: os.Getenv("MAILSMTPHOST"),
+		Port: os.Getenv("MAILSMTPPORT"),
+	}
+	msg := &Message{
+		senderName:  os.Getenv("MAILSENDERNAME"),
+		fromAddress: os.Getenv("MAILFROMADDRESS"),
+		toAddresses: strings.Split(os.Getenv("MAILTOADDRESSES"), ","),
+		subject:     mailSubject,
+		headers:     make(textproto.MIMEHeader),
+		body:        new(bytes.Buffer),
+		mailEnabled: strings.ToLower(os.Getenv("MAILENABLED")),
+	}
+
+	if msg.mailEnabled != "true" {
+		log.Println("Mail feature is not enabled")
+		return nil
+	}
+
+	// check msg fields
+	if msg.senderName == "" || msg.fromAddress == "" {
+		return fmt.Errorf("Error sending email: missing sender name and/or sender address")
+	}
+
+	msg.validateRecipientAddresses()
+
+	msg.SetFrom().AddTo(msg.toAddresses...).SetSubject().SetBody("mixed", f)
+	if msg.err != nil {
+		return fmt.Errorf("Error sending email: %s", msg.err)
+	}
+
+	msgString := msg.MIMEString()
+
+	err := smtp.SendMail(smtpRelay.Host+":"+smtpRelay.Port, nil, msg.fromAddress, msg.toAddresses, []byte(msgString))
+	if err != nil {
+		return fmt.Errorf("Error sending mail: %s", err)
+	}
+
+	log.Printf("successfully emailed %s", AttachedFileName)
+
+	return nil
+
+}

--- a/mail.go
+++ b/mail.go
@@ -30,249 +30,155 @@ const (
 	FileContentDisposition = "attachment"
 )
 
-const (
-	SMTPHost = "internal-Enterpris-SMTPProd-I20YLD1GTM6L-357506541.us-east-1.elb.amazonaws.com"
-	SMTPPort = "25"
-)
-
-type SMTPRelay struct {
-	Host string
-	Port string
+func setHeader(headers *textproto.MIMEHeader, key, value string) {
+	h := textproto.CanonicalMIMEHeaderKey(key)
+	headers.Set(h, value)
 }
 
-type Message struct {
-	fromAddress string
-	senderName  string
-	toAddresses []string
-	subject     string
-	headers     textproto.MIMEHeader
-	body        *bytes.Buffer
-	err         error
-	mailEnabled string
+func addHeader(headers *textproto.MIMEHeader, key, value string) {
+	h := textproto.CanonicalMIMEHeaderKey(key)
+	headers.Add(h, value)
 }
 
-type File struct {
-	name     string
-	mimeType string
-	data     []byte
-}
+// create a multipart MIME message with text and file attachment
+func setBody(headers *textproto.MIMEHeader, body *bytes.Buffer, f *excelize.File) error {
 
-func newFile(f *excelize.File) (*File, error) {
+	multipartType := "fixed"
+
+	// create a new multipart writer
+	writer := multipart.NewWriter(body)
+	contentType := "multipart/" + multipartType + ";\n \tboundary=" + writer.Boundary()
+	// add header to main header group
+	setHeader(headers, "Content-Type", contentType)
+
+	// add text part
+	textBody := "\r\nPlease see attached file with portal accounts.\r\n"
+	textHeader := make(textproto.MIMEHeader)
+	setHeader(&textHeader, "Content-Type", "text/plain; charset="+charSet)
+	setHeader(&textHeader, "Content-Transfer-Encoding", bodyEncoding)
+	p, err := writer.CreatePart(textHeader)
+	if err != nil {
+		return err
+	}
+	_, err = p.Write([]byte(b64.StdEncoding.EncodeToString([]byte(textBody))))
+	if err != nil {
+		return err
+	}
+
+	// add file attachment part
 	fp, err := os.Open(f.Path)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer fp.Close()
 
 	data, err := io.ReadAll(fp)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return &File{
-		name:     AttachedFileName,
-		mimeType: FileMimeType,
-		data:     data,
-	}, nil
-
-}
-
-func (m *Message) setHeader(header, value string) *Message {
-	h := textproto.CanonicalMIMEHeaderKey(header)
-	m.headers.Set(h, value)
-
-	return m
-}
-
-func (m *Message) addHeader(header, value string) *Message {
-	h := textproto.CanonicalMIMEHeaderKey(header)
-	m.headers.Add(h, value)
-
-	return m
-}
-
-func (m *Message) addRecipientAddresses(addresses ...string) *Message {
-	for _, addr := range addresses {
-		m.addHeader("To", addr)
-	}
-	return m
-}
-
-func (m *Message) SetFrom() *Message {
-	if m.err != nil {
-		return m
-	}
-
-	m.setHeader("From", m.senderName+" <"+m.fromAddress+">")
-	return m
-}
-
-func (m *Message) SetSubject() *Message {
-	if m.err != nil {
-		return m
-	}
-
-	m.setHeader("Subject", m.subject)
-	return m
-}
-
-func (m *Message) AddTo(addresses ...string) *Message {
-	if m.err != nil {
-		return m
-	}
-
-	m.addRecipientAddresses(addresses...)
-
-	return m
-}
-
-// create a multipart MIME message with text and file attachment
-func (m *Message) SetBody(multipartType string, f *excelize.File) *Message {
-	if m.err != nil {
-		return m
-	}
-
-	var header textproto.MIMEHeader
-
-	// create a new multipart writer
-	writer := multipart.NewWriter(m.body)
-	contentType := "multipart/" + multipartType + ";\n \tboundary=" + writer.Boundary()
-	// add header to main header group
-	m.setHeader("Content-Type", contentType)
-
-	// add text part
-	textBody := "\r\nPlease see attached file with portal accounts.\r\n"
-	header = make(textproto.MIMEHeader)
-	header.Set("Content-Type", "text/plain; charset="+charSet)
-	header.Set("Content-Transfer-Encoding", bodyEncoding)
-	p, err := writer.CreatePart(header)
+	fileHeader := make(textproto.MIMEHeader)
+	value := fmt.Sprintf("%s;\n \tname=%q", FileMimeType, AttachedFileName)
+	setHeader(&fileHeader, "Content-Type", value)
+	setHeader(&fileHeader, "Content-Transfer-Encoding", bodyEncoding)
+	value = fmt.Sprintf("attachment;\n \tfilename=%q", AttachedFileName)
+	setHeader(&fileHeader, "Content-Disposition", value)
+	p, err = writer.CreatePart(fileHeader)
 	if err != nil {
-		m.err = err
-		return m
+		return err
 	}
-	_, err = p.Write([]byte(b64.StdEncoding.EncodeToString([]byte(textBody))))
+	_, err = p.Write([]byte(b64.StdEncoding.EncodeToString(data)))
 	if err != nil {
-		m.err = err
-		return m
-	}
-
-	// add file attachment part
-	ft, err := newFile(f)
-	if err != nil {
-		m.err = err
-		return m
-	}
-
-	header = make(textproto.MIMEHeader)
-	value := fmt.Sprintf("%s;\n \tname=%q", ft.mimeType, ft.name)
-	header.Set("Content-Type", value)
-	header.Set("Content-Transfer-Encoding", bodyEncoding)
-	value = fmt.Sprintf("attachment;\n \tfilename=%q", ft.name)
-	header.Set("Content-Disposition", value)
-	p, err = writer.CreatePart(header)
-	if err != nil {
-		m.err = err
-		return m
-	}
-	_, err = p.Write([]byte(b64.StdEncoding.EncodeToString(ft.data)))
-	if err != nil {
-		m.err = err
-		return m
+		return err
 	}
 
 	err = writer.Close()
 	if err != nil {
-		m.err = err
-		return m
+		return err
 	}
 
-	return m
+	return nil
 }
 
-func (m *Message) MIMEString() string {
-	return m.getHeaders() + m.body.String()
+func toMIMEString(headers *textproto.MIMEHeader, body *bytes.Buffer) string {
+	return toHeaderString(headers) + body.String()
 }
 
-func (m *Message) getHeaders() (headers string) {
-	m.setHeader("Date", time.Now().Format(time.RFC1123Z))
+func toHeaderString(headers *textproto.MIMEHeader) string {
+	setHeader(headers, "Date", time.Now().Format(time.RFC1123Z))
 
 	// combine the headers
-	for header, values := range m.headers {
-		headers += header + ": " + strings.Join(values, ", ") + "\r\n"
+	strHeader := ""
+	for header, values := range *headers {
+		strHeader += header + ": " + strings.Join(values, ", ") + "\r\n"
 	}
 
-	headers = headers + "\r\n"
-
-	return
-
+	return strHeader + "\r\n"
 }
 
-func (m *Message) validateRecipientAddresses() *Message {
+func validateRecipientAddresses(addresses []string) ([]string, error) {
 	// remove duplicate addresses
 	// log invalid address and continue
 	// if no valid address, set m.err
-	addresses := make([]string, 0)
-	addressSet := make(map[string]bool)
-	for _, addr := range m.toAddresses {
+	validAddresses := make([]string, 0)
+	for _, addr := range addresses {
 		if len(addr) > 0 {
 			a, err := mail.ParseAddress(addr)
 			if err != nil {
 				log.Printf("validating recipient address %s: %s", addr, err)
 				continue
 			}
-			if _, ok := addressSet[a.Address]; !ok {
-				addressSet[a.Address] = true
-				addresses = append(addresses, a.Address)
-			}
+			validAddresses = append(validAddresses, a.Address)
 		} else {
 			continue
 		}
 	}
-	if len(addresses) == 0 {
-		m.err = fmt.Errorf("no valid recipient address")
-		return m
+	if len(validAddresses) == 0 {
+		return nil, fmt.Errorf("no valid recipient address")
 	}
 
-	m.toAddresses = addresses
-
-	return m
+	return validAddresses, nil
 }
 
 func sendEmail(f *excelize.File) error {
-	smtpRelay := &SMTPRelay{
-		Host: os.Getenv("MAILSMTPHOST"),
-		Port: os.Getenv("MAILSMTPPORT"),
-	}
-	msg := &Message{
-		senderName:  os.Getenv("MAILSENDERNAME"),
-		fromAddress: os.Getenv("MAILFROMADDRESS"),
-		toAddresses: strings.Split(os.Getenv("MAILTOADDRESSES"), ","),
-		subject:     mailSubject,
-		headers:     make(textproto.MIMEHeader),
-		body:        new(bytes.Buffer),
-		mailEnabled: strings.ToLower(os.Getenv("MAILENABLED")),
-	}
 
-	if msg.mailEnabled != "true" {
+	host := os.Getenv("MAILSMTPHOST")
+	port := os.Getenv("MAILSMTPPORT")
+
+	senderName := os.Getenv("MAILSENDERNAME")
+	fromAddress := os.Getenv("MAILFROMADDRESS")
+	toAddresses := strings.Split(os.Getenv("MAILTOADDRESSES"), ",")
+	headers := make(textproto.MIMEHeader)
+	body := new(bytes.Buffer)
+	mailEnabled := strings.ToLower(os.Getenv("MAILENABLED"))
+
+	if mailEnabled != "true" {
 		log.Println("Mail feature is not enabled")
 		return nil
 	}
 
-	// check msg fields
-	if msg.senderName == "" || msg.fromAddress == "" {
+	if senderName == "" || fromAddress == "" {
 		return fmt.Errorf("Error sending email: missing sender name and/or sender address")
 	}
 
-	msg.validateRecipientAddresses()
-
-	msg.SetFrom().AddTo(msg.toAddresses...).SetSubject().SetBody("mixed", f)
-	if msg.err != nil {
-		return fmt.Errorf("Error sending email: %s", msg.err)
+	validatedToAddresses, err := validateRecipientAddresses(toAddresses)
+	if err != nil {
+		return fmt.Errorf("Error sending email: %s", err)
 	}
 
-	msgString := msg.MIMEString()
+	setHeader(&headers, "From", fromAddress)
+	for _, address := range validatedToAddresses {
+		addHeader(&headers, "To", address)
+	}
+	setHeader(&headers, "Subject", mailSubject)
+	err = setBody(&headers, body, f)
+	if err != nil {
+		return fmt.Errorf("Error sending email: %s", err)
+	}
 
-	err := smtp.SendMail(smtpRelay.Host+":"+smtpRelay.Port, nil, msg.fromAddress, msg.toAddresses, []byte(msgString))
+	msgString := toMIMEString(&headers, body)
+
+	err = smtp.SendMail(host+":"+port, nil, fromAddress, validatedToAddresses, []byte(msgString))
 	if err != nil {
 		return fmt.Errorf("Error sending mail: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -242,6 +242,11 @@ func rotate(input *Input, envToPortal map[Environment]*Portal, client S3ClientAP
 		}
 
 	}
+
+	err = sendEmail(f)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -243,7 +243,7 @@ func rotate(input *Input, envToPortal map[Environment]*Portal, client S3ClientAP
 
 	}
 
-	err = sendEmail(f)
+	err = sendEmail(f.Path)
 	if err != nil {
 		return err
 	}

--- a/password-rotation/README.md
+++ b/password-rotation/README.md
@@ -3,7 +3,9 @@
 A Terraform module which deploys a scheduled ECS task on a cron schedule.  This task runs an application which pulls a test user spreadsheet from S3, rotates the Enterprise Portal passwords for the test users, updates the spreadsheet, and pushes it back to S3. To read more about the password rotation application, see the README (TBD)
 
 ## Usage
-See [variables.tf](variables.tf) for variable descriptions. To enable the scheduled task to run, uncomment `event_rule_enabled = true`. To disable it, comment out the line.
+See [variables.tf](variables.tf) for variable descriptions.
+To enable the scheduled task to run, uncomment `event_rule_enabled = true`. To disable it, comment out the line.
+To enable the application to send email, uncomment `mail_enabled = "true" . To disable it, comment out the line.
 ```
 module "password-rotation" {
   source      = "github.com/CMSgov/portal-test-user-manager//password-rotation
@@ -23,6 +25,9 @@ module "password-rotation" {
   sheet_name_dev       = ""
   sheet_name_val       = ""
   sheet_name_prod      = ""
+
+  # mail_enabled = "true"
+  to_addresses = "macfintestingteam@dcca.com" // Separate multiple addresses with a comma.
 }
 ```
 

--- a/password-rotation/container-definitions.json
+++ b/password-rotation/container-definitions.json
@@ -22,7 +22,6 @@
       {"name": "MAILSENDERNAME", "value": "${sender_name}" },
       {"name": "MAILTOADDRESSES", "value": "${to_addresses}" },
       {"name": "MAILENABLED", "value": "${mail_enabled}" }
-
     ],
     "secrets": [
       {

--- a/password-rotation/container-definitions.json
+++ b/password-rotation/container-definitions.json
@@ -15,7 +15,14 @@
       { "name": "PORTALHOSTNAMEPROD", "value": "${portal_hostname_prod}" },
       { "name": "IDMHOSTNAMEDEV", "value": "${idm_hostname_dev}" },
       { "name": "IDMHOSTNAMEVAL", "value": "${idm_hostname_val}" },
-      { "name": "IDMHOSTNAMEPROD", "value": "${idm_hostname_prod}" }
+      { "name": "IDMHOSTNAMEPROD", "value": "${idm_hostname_prod}" },
+      {"name": "MAILSMTPHOST", "value": "${smtp_host}" },
+      {"name": "MAILSMTPPORT", "value": "${smtp_port}" },
+      {"name": "MAILFROMADDRESS", "value": "${from_address}" },
+      {"name": "MAILSENDERNAME", "value": "${sender_name}" },
+      {"name": "MAILTOADDRESSES", "value": "${to_addresses}" },
+      {"name": "MAILENABLED", "value": "${mail_enabled}" }
+
     ],
     "secrets": [
       {

--- a/password-rotation/main.tf
+++ b/password-rotation/main.tf
@@ -26,10 +26,10 @@ data "aws_iam_policy_document" "events_assume_role_policy" {
 }
 
 resource "aws_iam_role" "cloudwatch_target_role" {
-  name                = "cw-target-role-${var.app_name}-${var.environment}-${var.task_name}"
-  description         = "Role allowing CloudWatch Events to run the task"
-  assume_role_policy  = data.aws_iam_policy_document.events_assume_role_policy.json
-  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"]
+  name                 = "cw-target-role-${var.app_name}-${var.environment}-${var.task_name}"
+  description          = "Role allowing CloudWatch Events to run the task"
+  assume_role_policy   = data.aws_iam_policy_document.events_assume_role_policy.json
+  managed_policy_arns  = ["arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole"]
 }
 
 ## ECS roles
@@ -52,10 +52,10 @@ data "aws_iam_policy_document" "ecs_assume_role_policy" {
 # ECS task role
 
 resource "aws_iam_role" "task_role" {
-  name                = "ecs-task-role-${var.app_name}-${var.environment}-${var.task_name}"
-  description         = "Role granting permissions to the ECS container task"
-  assume_role_policy  = data.aws_iam_policy_document.ecs_assume_role_policy.json
-  managed_policy_arns = [aws_iam_policy.s3_access.arn]
+  name                 = "ecs-task-role-${var.app_name}-${var.environment}-${var.task_name}"
+  description          = "Role granting permissions to the ECS container task"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  managed_policy_arns  = [aws_iam_policy.s3_access.arn]
 }
 
 data "aws_iam_policy_document" "s3_access" {
@@ -75,10 +75,10 @@ resource "aws_iam_policy" "s3_access" {
 # ECS task execution role
 
 resource "aws_iam_role" "task_execution_role" {
-  name                = "ecs-task-exec-role-${var.app_name}-${var.environment}-${var.task_name}"
-  description         = "Role granting permissions to the ECS container agent/Docker daemon"
-  assume_role_policy  = data.aws_iam_policy_document.ecs_assume_role_policy.json
-  managed_policy_arns = [aws_iam_policy.parameter_store.arn, "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
+  name                 = "ecs-task-exec-role-${var.app_name}-${var.environment}-${var.task_name}"
+  description          = "Role granting permissions to the ECS container agent/Docker daemon"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_assume_role_policy.json
+  managed_policy_arns  = [aws_iam_policy.parameter_store.arn, "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
 }
 
 data "aws_iam_policy_document" "parameter_store" {
@@ -281,6 +281,14 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
 
       awslogs_group  = local.awslogs_group,
       awslogs_region = data.aws_region.current.name
+
+      smtp_port    = var.smtp_port
+      smtp_host    = var.smtp_host
+      from_address = var.from_address
+      sender_name  = var.sender_name
+      to_addresses = var.to_addresses
+      mail_enabled = var.mail_enabled
+
     }
   )
 }

--- a/password-rotation/variables.tf
+++ b/password-rotation/variables.tf
@@ -119,3 +119,35 @@ variable "idm_hostname_prod" {
   description = "Hostname for prod CMS Enterprise Portal IDM"
   default     = "idm.cms.gov"
 }
+
+# MAIL variables
+variable "smtp_host" {
+  type    = string
+  default = "internal-Enterpris-SMTPProd-I20YLD1GTM6L-357506541.us-east-1.elb.amazonaws.com"
+}
+
+variable "smtp_port" {
+  type    = string
+  default = "25"
+}
+
+variable "from_address" {
+  type    = string
+  default = "no-reply-macfin-ecs-job@cms.hhs.gov"
+}
+
+variable "sender_name" {
+  type    = string
+  default = "macfin-ecs-job"
+}
+
+variable "to_addresses" {
+  description = "comma-separated email addresses"
+  type    = string
+  default = "macfintestingteam@dcca.com"
+}
+
+variable "mail_enabled" {
+  type = string
+  default = "false"
+}

--- a/password-rotation/variables.tf
+++ b/password-rotation/variables.tf
@@ -143,11 +143,11 @@ variable "sender_name" {
 
 variable "to_addresses" {
   description = "comma-separated email addresses"
-  type    = string
-  default = "macfintestingteam@dcca.com"
+  type        = string
+  default     = "macfintestingteam@dcca.com"
 }
 
 variable "mail_enabled" {
-  type = string
+  type    = string
   default = "false"
 }


### PR DESCRIPTION
If enabled, the application emails the file after processing all portal sheets.
The application sends the email to recipient address(es).
This PR has the send mail feature disabled.

Tested:
Deployed the scheduled task.
When disabled: verified the log entry: `Mail feature is not enabled`
When enabled: 
- verified the log entry: `successfully emailed MACFin_test_accounts.xlsx`
- received email with the attached file at 2 addresses
Tested with missing from: address, to: address, duplicate to: addresses, 