### PR TITLE
prefix info log entries with `Info` and use this as log filter

### DIFF
--- a/excel.go
+++ b/excel.go
@@ -162,7 +162,7 @@ func removeMACFinUserDups(f *excelize.File, input *Input, env Environment) error
 	for idx := len(rows) - 1; idx >= rowOffset; idx-- {
 		err := validateRow(f, sheetName, idx, usernameXCoord, passwordXCoord)
 		if err != nil {
-			log.Printf("validating sheet %s, row %d: %s", sheetName, toSheetCoord(idx), err)
+			log.Printf("Info: validating sheet %s, row %d: %s", sheetName, toSheetCoord(idx), err)
 			continue
 		}
 		if _, ok := users[strings.ToLower(rows[idx][usernameXCoord])]; ok {
@@ -211,7 +211,7 @@ func getMACFinUsers(f *excelize.File, input *Input, env Environment) (map[string
 	for i, row := range rows[rowOffset:] {
 		err := validateRow(f, sheetName, i+rowOffset, usernameXCoord, passwordXCoord)
 		if err != nil {
-			log.Printf("validating sheet %s, row %d: %s", sheetName, toSheetCoord(i+rowOffset), err)
+			log.Printf("Info: validating sheet %s, row %d: %s", sheetName, toSheetCoord(i+rowOffset), err)
 			continue
 		}
 		users[strings.ToLower(row[usernameXCoord])] = PasswordRow{row[passwordXCoord], i + rowOffset}
@@ -421,7 +421,7 @@ func updateMACFinUsers(f *excelize.File, input *Input, client S3ClientAPI, env E
 	for i, row := range rows[rowOffset:] {
 		err := validateRow(f, sheetName, i+rowOffset, userX, passwordX)
 		if err != nil {
-			log.Printf("validating sheet %s, row %d: %s", sheetName, toSheetCoord(i+rowOffset), err)
+			log.Printf("Info: validating sheet %s, row %d: %s", sheetName, toSheetCoord(i+rowOffset), err)
 			continue
 		}
 

--- a/password-rotation/main.tf
+++ b/password-rotation/main.tf
@@ -188,7 +188,7 @@ resource "aws_cloudwatch_metric_alarm" "error_count" {
 
 resource "aws_cloudwatch_log_metric_filter" "info_count" {
   name           = "${var.app_name}-info-count"
-  pattern        = "validating sheet"
+  pattern        = "Info"
   log_group_name = local.awslogs_group
 
   metric_transformation {


### PR DESCRIPTION
Adds a prefix of `Info` to all log entries that do not cause the program to stop and which need a human's attention.
The prefix is used as a log filter. An alarm, associated with this filter, triggers an `Info` notification sent to the testing team so they can take action.

Tested:
Set a To: Address to an invalid value. The code logged an entry prefixed with `Info`, which triggered a notification to my email.
When fixed, alarm cleared, received another email with alarm => OK.

