### PR TITLE
fix cron expression format

### DIFF
--- a/password-rotation/variables.tf
+++ b/password-rotation/variables.tf
@@ -39,7 +39,7 @@ variable "ecs_subnet_ids" {
 variable "schedule_task_expression" {
   type        = string
   description = "Cron based schedule task to run on a cadence"
-  default     = "0 8 1 * ? *" // monthly on the first day of the month at 8am UTC (3am UTC-5)
+  default     = "cron(0 8 1 * ? *)" // monthly on the first day of the month at 8am UTC (3am UTC-5)
 }
 
 variable "event_rule_enabled" {


### PR DESCRIPTION
This PR fixes the cron expression format used for the scheduled task running the password-rotation application.
Sam found this error when he tried to deploy with the default value.