### PR TITLE
Add MACFin account

### DIFF
--- a/aws-cms-oit-iusg-spe-cmcs-macbis-test/ecr.tf
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-test/ecr.tf
@@ -1,8 +1,11 @@
 module "cross_account_ecr" {
   source = "../cross-account-ecr"
 
-  principal_arns = ["arn:aws:iam::037370603820:root", "arn:aws:iam::741306476019:root"] // macbis-dev, MACFin
-  repo_name  = "password-rotation"
+  principal_arns = [
+    "arn:aws:iam::037370603820:root", # macbis-dev
+    "arn:aws:iam::741306476019:root"  # MACFin
+  ]
+  repo_name = "password-rotation"
 }
 
 output "cross_account_ecr_outputs" {

--- a/aws-cms-oit-iusg-spe-cmcs-macbis-test/ecr.tf
+++ b/aws-cms-oit-iusg-spe-cmcs-macbis-test/ecr.tf
@@ -1,7 +1,7 @@
 module "cross_account_ecr" {
   source = "../cross-account-ecr"
 
-  account_id = "037370603820"
+  principal_arns = ["arn:aws:iam::037370603820:root", "arn:aws:iam::741306476019:root"] // macbis-dev, MACFin
   repo_name  = "password-rotation"
 }
 

--- a/cross-account-ecr/main.tf
+++ b/cross-account-ecr/main.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "cross_account_access" {
     ]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+      identifiers = var.principal_arns
     }
     effect = "Allow"
   }

--- a/cross-account-ecr/variables.tf
+++ b/cross-account-ecr/variables.tf
@@ -1,6 +1,6 @@
-variable "account_id" {
-  type        = string
-  description = "Account ID that will be pulling the image"
+variable "principal_arns" {
+  type        = list(string)
+  description = "ARNs to grant ECR access to"
 }
 
 variable "repo_name" {


### PR DESCRIPTION
Changes the input to the module to a list of ARNs so we can add the MACFin account

Testing: 
Applied Terraform and confirmed policy in AWS console