### PR TITLE
password-rotation module: remediate security findings

### DIFF
--- a/password-rotation/main.tf
+++ b/password-rotation/main.tf
@@ -218,7 +218,8 @@ resource "aws_cloudwatch_metric_alarm" "info_count" {
 ## SNS ##
 
 resource "aws_sns_topic" "password_rotation" {
-  name = var.app_name
+  name              = var.app_name
+  kms_master_key_id = "alias/aws/sns"
 }
 
 ## ECS ##

--- a/password-rotation/main.tf
+++ b/password-rotation/main.tf
@@ -362,3 +362,27 @@ resource "aws_s3_bucket_public_access_block" "spreadsheet" {
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
+
+resource "aws_s3_bucket_policy" "ssl_only" {
+  bucket = aws_s3_bucket.spreadsheet.id
+  policy = data.aws_iam_policy_document.ssl_only.json
+}
+
+data "aws_iam_policy_document" "ssl_only" {
+  statement {
+    actions   = ["s3:*"]
+    resources = ["arn:aws:s3:::${var.s3_bucket}", "arn:aws:s3:::${var.s3_bucket}/*"]
+    effect    = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}

--- a/password-rotation/main.tf
+++ b/password-rotation/main.tf
@@ -353,3 +353,12 @@ resource "aws_s3_bucket" "spreadsheet" {
     }
   }
 }
+
+resource "aws_s3_bucket_public_access_block" "spreadsheet" {
+  bucket = aws_s3_bucket.spreadsheet.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
This PR addresses security findings:
S3 bucket public access is not blocked
S3 bucket policy is missing deny to requests that are not "SSL"
SNS topic does not use AWS KMS key to encrypt at rest

Tested:
deployed these changes to MACBIS Shared DEV and verified the findings are no longer Active